### PR TITLE
Dev

### DIFF
--- a/templates/point/opens.html.twig
+++ b/templates/point/opens.html.twig
@@ -39,7 +39,7 @@
                 columns: ['Élève', 'Rendu 1', 'Rendu 2'],
                 server: {
                     url: `${window.location.origin}/get/NJXWQYLONZQWM2LMNFXWY`,
-                    then: data => data.map(eleve => [gridjs.html(`<a href="${window.location.origin}/NJXWQYLONZQWM2LMNFXWY/${eleve.id}">${eleve.name} (${eleve.classe}) ${eleve.warning}</a>`), eleve.r1, eleve.r2, ])
+                    then: data => data.map(eleve => [gridjs.html(`<a href="${window.location.origin}/NJXWQYLONZQWM2LMNFXWY/${eleve.id}">${eleve.name} (${eleve.classe}) ${eleve.warning}</a>`), Math.round(eleve.r1*100)/100, Math.round(eleve.r2*100)/100 ])
                 }
             }).render(document.getElementById("wrapper"));
             console.log(grid);


### PR DESCRIPTION
This pull request makes a small but important improvement to the way student scores are displayed in the `templates/point/opens.html.twig` file. Instead of showing raw values for the `r1` and `r2` columns, the scores are now rounded to two decimal places for better readability.

- Displayed student scores (`r1` and `r2`) are now rounded to two decimal places in the grid view for improved clarity.