### PR TITLE
fix : update point calculations and display in point detail view

### DIFF
--- a/src/Controller/PointController.php
+++ b/src/Controller/PointController.php
@@ -95,24 +95,21 @@ final class PointController extends AbstractController
         $userPoints[2]['o'] = 0;
         $userPoints[3]['o'] = 0;
 
-        $dates = [];
+        $dates = [1 => [], 2 => [], 3 => []];
         for ($i = 1; $i <= 3; $i++) {
             foreach ($userPoints[$i]['points'] as $point) {
-                if ($point->getReason() == "Présence à l'association en présentiel") {
-                    $userPoints[$i]['p']++;
-                    $dates[$i][] = $point->getDate()->format('d/m/Y');
+                if (in_array($point->getReason(), [ "Présence à l'association en présentiel", "Bonne réponse", "Mauvaise réponse", "Image acceptée"])) {
+                    $userPoints[$i]['p']+= $point->getPoints();
+                    $dates[$i][] = ['date' =>$point->getDate()->format('d/m/Y'), 'points'=>$point->getPoints()];
                 } else {
-                    $userPoints[$i]['o']++;
+                    $userPoints[$i]['o']+= $point->getPoints();
                 }
             }
         }
-        $userPoints[1]['p'] = min($userPoints[1]['p'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-        $userPoints[2]['p'] = min($userPoints[2]['p'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-        $userPoints[3]['p'] = min($userPoints[3]['p'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-        $userPoints[1]['o'] = min($userPoints[1]['o'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-        $userPoints[2]['o'] = min($userPoints[2]['o'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-        $userPoints[3]['o'] = min($userPoints[3]['o'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
-
+        $userPoints[1]['realTotal'] = min($userPoints[1]['total'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
+        $userPoints[2]['realTotal'] = min($userPoints[2]['total'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
+        $userPoints[3]['realTotal'] = min($userPoints[3]['total'], $user->getIsAdmin() == 0 ? 4 : ($user->getIsAdmin() == 1 ? 6 : 8));
+        dump($userPoints, $dates);
         return $this->render('point/point_detail.html.twig', [
             'point' => $userPoints,
             'dates' => $dates

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -737,7 +737,7 @@ class User implements PasswordAuthenticatedUserInterface, UserInterface
             "5MCSIJ",
         ];
         if (in_array($this->getClasse(), $octobre)) {
-            return "octobre";
+            return "septembre";
         } else if (in_array($this->getClasse(), $janvier)) {
             return "janvier";
         } else {

--- a/templates/point/point_detail.html.twig
+++ b/templates/point/point_detail.html.twig
@@ -18,12 +18,12 @@
         <div class="row">
             <div class="col-md-6">
                 <div class="card text-white bg-primary mb-3">
-                    <div class="card-header">Rendu 1 - {{ point.2.total }} points OPEN</div>
+                    <div class="card-header">Rendu 1 - {{ point.2.total }} points OPEN {{ point.2.realTotal != point.2.total ?"arrondis à "~point.2.realTotal ~ " points": ""  }}</div>
                     <div class="card-body bg-light">
                         <h5 class="card-title">Points OPEN gagnés sur les présences : {{ point.2.p }}</h5>
                         <ul>
                             {% for date in dates.2 %}
-                                <li>{{ date }} : 0.5 pt</li>
+                                <li>{{ date.date }} : {{ date.points }} pt</li>
                             {% endfor %}
                         </ul>
                         <p class="card-text">Points OPEN gagnés grâce à l'activité : {{ point.2.o }}</p>
@@ -32,12 +32,12 @@
             </div>
             <div class="col-md-6">
                 <div class="card text-white bg-primary mb-3">
-                    <div class="card-header">Rendu 2 - {{ point.3.total }} points OPEN</div>
+                    <div class="card-header">Rendu 2 - {{ point.3.total }} points OPEN {{ point.3.realTotal != point.3.total ? "arrondis à "~ point.3.realTotal ~ " points": ""  }}</div>
                     <div class="card-body bg-light">
                         <h5 class="card-title">Points OPEN gagnés sur les présences : {{ point.3.p }}</h5>
                         <ul>
                             {% for date in dates.3 %}
-                                <li>{{ date }} : 0.5 pt </li>
+                                <li>{{ date.date }} : {{ date.points }} pt </li>
                             {% endfor %}
                         </ul>
                         <p class="card-text">Points OPEN gagnés grâce à l'activité : {{ point.3.o }}</p>


### PR DESCRIPTION
This pull request updates the logic for calculating and displaying user points in both the backend (`PointController.php`) and the frontend template (`point_detail.html.twig`). The changes improve how points are summed, categorized, and presented, and also fix a mislabeling of the rentrée period in the user entity.

**Backend logic improvements:**

* Updated the point calculation in `PointController.php` to:
  - Sum points based on multiple reasons (not just presence).
  - Store both the date and the number of points for each entry in the `$dates` array.
  - Introduce a new `realTotal` field that applies an upper limit to the total points, depending on the user's admin status, instead of limiting `p` and `o` separately.

**Frontend display enhancements:**

* Modified `point_detail.html.twig` to:
  - Display the adjusted total (`realTotal`) if it differs from the calculated total for each "Rendu".
  - Show the actual number of points per date instead of a hardcoded value, reflecting the backend changes. [[1]](diffhunk://#diff-de90b78ad30e26b7d4b6aa4f9d826ae9c6acde0001663be7604c2ed90f1a55deL21-R26) [[2]](diffhunk://#diff-de90b78ad30e26b7d4b6aa4f9d826ae9c6acde0001663be7604c2ed90f1a55deL35-R40)

**Bug fix:**

* Corrected the return value in `User.php` so that classes in the `$octobre` array are now associated with "septembre" instead of "octobre" for the rentrée period.